### PR TITLE
pgp credential wrapping

### DIFF
--- a/camCipher/build.gradle
+++ b/camCipher/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 22
     buildToolsVersion '23.0.1'
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 21
     }
     buildTypes {

--- a/camCipher/src/main/AndroidManifest.xml
+++ b/camCipher/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="2.0.1-dev" >
 
     <uses-sdk
-        android:minSdkVersion="14"
+        android:minSdkVersion="19"
         android:targetSdkVersion="19" />
         <uses-permission android:name="android.permission.CAMERA" />
         <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/cameraVApp/build.gradle
+++ b/cameraVApp/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "org.witness.informacam.app"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 21
         multiDexEnabled true
 

--- a/cameraVApp/src/main/AndroidManifest.xml
+++ b/cameraVApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="0.2.4">
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="19"
         android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 android.useDeprecatedNdk=true
-#aar.deployPath=/home/n8fr8/dev/repos/gpgradle
 org.gradle.daemon=true

--- a/informaCam/build.gradle
+++ b/informaCam/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '23.0.1'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 21
         multiDexEnabled true
 

--- a/informaCam/src/main/AndroidManifest.xml
+++ b/informaCam/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="16"
+        android:minSdkVersion="19"
         android:targetSdkVersion="19" />
 
 

--- a/informaCam/src/main/java/org/witness/informacam/InformaCam.java
+++ b/informaCam/src/main/java/org/witness/informacam/InformaCam.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringBufferInputStream;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -326,7 +327,7 @@ public class InformaCam extends MultiDexApplication {
 		sendBroadcast(intent);
 	}
 	
-	public void initData() throws PGPException, IllegalAccessException, InstantiationException, IOException {
+	public void initData() throws PGPException, IllegalAccessException, InstantiationException, IOException, GeneralSecurityException {
 
 		try {
 			ISecretKey sKey = (ISecretKey) getModel(new ISecretKey());

--- a/informaCam/src/main/java/org/witness/informacam/crypto/KeyUtility.java
+++ b/informaCam/src/main/java/org/witness/informacam/crypto/KeyUtility.java
@@ -5,15 +5,20 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -45,28 +50,32 @@ import org.spongycastle.openpgp.PGPUtil;
 import org.spongycastle.util.encoders.Hex;
 import org.witness.informacam.InformaCam;
 import org.witness.informacam.json.JSONArray;
-import org.witness.informacam.json.JSONException;
 import org.witness.informacam.json.JSONObject;
 import org.witness.informacam.json.JSONTokener;
 import org.witness.informacam.models.credentials.IKeyStore;
 import org.witness.informacam.models.credentials.ISecretKey;
-import org.witness.informacam.models.notifications.INotification;
 import org.witness.informacam.models.organizations.IOrganization;
 import org.witness.informacam.storage.FormUtility;
 import org.witness.informacam.storage.IOUtility;
+import org.witness.informacam.utils.Constants.Logger;
 import org.witness.informacam.utils.Constants.App;
 import org.witness.informacam.utils.Constants.App.Storage;
 import org.witness.informacam.utils.Constants.App.Storage.Type;
 import org.witness.informacam.utils.Constants.Codes;
 import org.witness.informacam.utils.Constants.IManifest;
-import org.witness.informacam.utils.Constants.Models;
 import org.witness.informacam.utils.Constants.Models.ICredentials;
 import org.witness.informacam.utils.Constants.Models.IUser;
 
 import android.os.Bundle;
 import android.os.Message;
+import android.security.KeyPairGeneratorSpec;
 import android.util.Base64;
 import android.util.Log;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.security.auth.x500.X500Principal;
 
 public class KeyUtility {
 
@@ -132,9 +141,9 @@ public class KeyUtility {
 			product[b] = (byte) (baseBytes[b] ^ randomBytes[b]);
 		}
 
-		// digest to SHA1 string, voila password.
-		MessageDigest md = MessageDigest.getInstance("SHA-1");
-		return Base64.encodeToString(md.digest(product), Base64.DEFAULT);
+		// digest to SHA-256 string, voila password.
+		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		return new String(Hex.encode(md.digest(product)));
 	}
 
 	@SuppressWarnings("deprecation")
@@ -265,6 +274,71 @@ public class KeyUtility {
 			Log.e(LOG, e.toString(),e);
 		}
 	}
+
+    public static String unwrapSecretAuthToken(String secretAuthToken) throws GeneralSecurityException, IOException {
+        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        keyStore.load(null);
+
+        final KeyStore.PrivateKeyEntry pke = (KeyStore.PrivateKeyEntry) keyStore.getEntry(ICredentials.PASSWORD_ALIAS, null);
+        final KeyPair keyPair = new KeyPair(pke.getCertificate().getPublicKey(), pke.getPrivateKey());
+
+        final Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding", "AndroidOpenSSL");
+        cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+
+        CipherInputStream cis = new CipherInputStream(
+                new ByteArrayInputStream(Base64.decode(secretAuthToken.getBytes("UTF-8"), Base64.DEFAULT)), cipher);
+
+        ArrayList<Byte> a_bytes = new ArrayList<Byte>();
+        int next;
+        while ((next = cis.read()) != -1) {
+            a_bytes.add((byte) next);
+        }
+
+        byte[] bytes = new byte[a_bytes.size()];
+        for(int b=0; b<bytes.length; b++) {
+            bytes[b] = a_bytes.get(b).byteValue();
+        }
+
+        return new String(bytes, 0, bytes.length, "UTF-8");
+    }
+
+    private static String wrapSecretAuthToken(String secretAuthToken) throws GeneralSecurityException, IOException {
+        // encrypt to Android Keystore first.
+
+        final Calendar start = new GregorianCalendar();
+        final Calendar end = new GregorianCalendar();
+        end.add(Calendar.YEAR, 100);
+
+        final KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+        keyStore.load(null);
+
+        final KeyPairGeneratorSpec kpgSpec = new KeyPairGeneratorSpec.Builder(InformaCam.getInstance())
+                .setAlias(ICredentials.PASSWORD_ALIAS)
+                .setSubject(new X500Principal(String.format("CN=%s", ICredentials.PASSWORD_ALIAS)))
+                .setSerialNumber(BigInteger.ONE)
+                .setStartDate(start.getTime())
+                .setEndDate(end.getTime()).build();
+
+        final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "AndroidKeyStore");
+        kpg.initialize(kpgSpec);
+        kpg.generateKeyPair();
+
+        final KeyStore.PrivateKeyEntry pke = (KeyStore.PrivateKeyEntry) keyStore.getEntry(ICredentials.PASSWORD_ALIAS, null);
+        final KeyPair keyPair = new KeyPair(pke.getCertificate().getPublicKey(), pke.getPrivateKey());
+
+        final Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding", "AndroidOpenSSL");
+        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CipherOutputStream cos = new CipherOutputStream(baos, cipher);
+        cos.write(secretAuthToken.getBytes("UTF-8"));
+        cos.close();
+
+        byte[] secretAuthTokenBytes = baos.toByteArray();
+        baos.close();
+
+        return Base64.encodeToString(secretAuthTokenBytes, Base64.DEFAULT);
+    }
 	
 	private static boolean initDeviceKeys (String authToken, byte[] baseImageBytes)
 	{
@@ -279,18 +353,16 @@ public class KeyUtility {
 			
 			String secretAuthToken, keyStorePassword;
 
-			progress += 10;
-			data.putInt(Codes.Keys.UI.PROGRESS, progress);
+            progress += 10;
+            data.putInt(Codes.Keys.UI.PROGRESS, progress);
 			informaCam.update(data);
 
-			secretAuthToken = generatePassword(baseImageBytes);
+            secretAuthToken = generatePassword(baseImageBytes);
 			keyStorePassword = generatePassword(baseImageBytes);
 			
 			// TODO: set up anonymization vector here
 			
 			baseImageBytes = null;
-
-			//informaCam.ioService.initIOCipher(authToken);
 
 			progress += 10;
 			data.putInt(Codes.Keys.UI.PROGRESS, progress);
@@ -372,7 +444,7 @@ public class KeyUtility {
 
 			ISecretKey secretKeyPackage = new ISecretKey();
 			secretKeyPackage.pgpKeyFingerprint = pgpKeyFingerprint;
-			secretKeyPackage.secretAuthToken = secretAuthToken;
+			secretKeyPackage.secretAuthToken = wrapSecretAuthToken(secretAuthToken);
 			secretKeyPackage.secretKey = Base64.encodeToString(secret.getEncoded(), Base64.DEFAULT);
 
 			progress += 10;

--- a/informaCam/src/main/java/org/witness/informacam/crypto/SignatureService.java
+++ b/informaCam/src/main/java/org/witness/informacam/crypto/SignatureService.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Reader;
+import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 
@@ -38,15 +38,14 @@ public class SignatureService {
 	
 	private static String LOG = Crypto.LOG;
 	
-	public SignatureService (Context context)
-	{
-		
-	}
+	public SignatureService (Context context) {}
 	
 	
 	@SuppressWarnings({"deprecation" })
-	public void initKey(ISecretKey sk) throws PGPException {
-		authKey = sk.secretAuthToken;
+	public void initKey(ISecretKey sk) throws PGPException, GeneralSecurityException, IOException {
+		// decrypt secretAuthToken with Android Keystore first.
+		authKey = KeyUtility.unwrapSecretAuthToken(sk.secretAuthToken);
+
 		secretKey = KeyUtility.extractSecretKey(sk.secretKey.getBytes());
 		privateKey = secretKey.extractPrivateKey(authKey.toCharArray(), new BouncyCastleProvider());
 		publicKey = secretKey.getPublicKey();

--- a/informaCam/src/main/java/org/witness/informacam/utils/Constants.java
+++ b/informaCam/src/main/java/org/witness/informacam/utils/Constants.java
@@ -531,6 +531,7 @@ public class Constants {
 
 		public class ICredentials {
 			public final static String PASSWORD_BLOCK = "passwordBlock";
+			public final static String PASSWORD_ALIAS = "CameraV1_2";
 		}
 
 		public class IPendingConnections {


### PR DESCRIPTION
implemented android keystore for pgp key credential wrapping as per https://github.com/harlo/CameraV/issues/3. this required updating min sdk to at least 18 (went with 19)
